### PR TITLE
Bugfix/buffer overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 target/
 .idea/
 *.iml
+.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.synack</groupId>
     <artifactId>maven-wagon-gs</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Maven Wagon that can resolve and retrieve artifacts from Google Storage</description>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>http://www.github.com/synack/maven-wagon-gs</url>
 
@@ -33,11 +34,22 @@
         </developer>
     </developers>
 
+    <scm>
+        <connection>scm:git:git@github.com:synack/maven-wagon-gs.git</connection>
+        <developerConnection>scm:git:git@github.com:synack/maven-wagon-gs.git</developerConnection>
+        <url>http://github.com/synack/maven-wagon-gs/tree/master</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
+        <repository>
+            <id>bintray-ottogroup-maven</id>
+            <url>https://api.bintray.com/maven/ottogroup/maven/maven-wagon-gs</url>
+        </repository>
     </distributionManagement>
 
     <build>
@@ -49,26 +61,6 @@
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <releaseProfiles>releases</releaseProfiles>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <executions>
-                  <execution>
-                     <id>default-deploy</id>
-                     <phase>deploy</phase>
-                     <goals>
-                        <goal>deploy</goal>
-                     </goals>
-                  </execution>
-               </executions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
             <plugin>
@@ -106,29 +98,8 @@
                     </tags>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
-    <scm>
-        <connection>scm:git:git@github.com:synack/maven-wagon-gs.git</connection>
-        <developerConnection>scm:git:git@github.com:synack/maven-wagon-gs.git</developerConnection>
-        <url>http://github.com/synack/maven-wagon-gs/tree/master</url>
-      <tag>HEAD</tag>
-  </scm>
 
     <dependencies>
         <dependency>
@@ -171,4 +142,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/src/main/java/com/synack/maven/wagon/gs/GSWagon.java
+++ b/src/main/java/com/synack/maven/wagon/gs/GSWagon.java
@@ -62,7 +62,7 @@ public class GSWagon extends StreamWagon {
             throw new TransferFailedException(String.format("Cannot find bucket '%s'", getBucketName()));
         }
 
-        final Blob blob = bucket.get(outputData.getResource().getName());
+        final Blob blob = bucket.create(outputData.getResource().getName(), new byte[]{});
 
         final OutputStream outputStream = Channels.newOutputStream(blob.writer());
         outputData.setOutputStream(outputStream);


### PR DESCRIPTION
Changed pom.xml such that we can deploy to ottogroup bintray more easily in the future.

In order to get mvn to accept a build extension not from maven central, you have to explicitly download it to your local repo. E.g.,

`mvn -DremoteRepositories=https://dl.bintray.com/ottogroup/maven/ -Dartifact=com.synack:maven-wagon-gs:0.7 -U -B dependency:get`

You also have to remove any remaining vestige pointing to ottogroup bintray:

E.g.,

`rm /root/.m2/repository/com/synack/maven-wagon-gs/0.7/_remote.repositories` 
